### PR TITLE
Added canonical name to bridge interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-ansible_home/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ansible_home/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -155,5 +155,8 @@ services:
 networks:
   diveinto.io:
     name: diveinto.io
-    driver_opts:
-      com.docker.network.bridge.name: "diveinto.io"
+    # Canonical bridge interface name
+    # The setting below will allow easy recognizing the bridge interface
+    # 
+    #driver_opts:
+    #  com.docker.network.bridge.name: "diveinto.io"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -155,3 +155,5 @@ services:
 networks:
   diveinto.io:
     name: diveinto.io
+    driver_opts:
+      com.docker.network.bridge.name: "diveinto.io"


### PR DESCRIPTION
This change will name the bridge interface 'diveinto.io'. This allows for easy recognizing the interface using  the 'ip' command.

Furthermore, this change will allow binding a host DNS server to the interface name in a more robust way. Personally using dnsmasq as a local DNS forwarder. Example dnsmasq config:
```
..
interface=lo,docker0,diveinto.io
no-dhcp-interface=lo,docker0,diveinto.io
bind-interfaces
..
```